### PR TITLE
Conflicts with CSS frameworks like the Twitter Bootstrap

### DIFF
--- a/scss/marionette.modal.scss
+++ b/scss/marionette.modal.scss
@@ -23,4 +23,5 @@
     padding: 1.5rem;
     display: none;
     opacity: 0;
+    bottom:auto;
 }


### PR DESCRIPTION
Correct the conflit between bootstrap 3 .modal and the project .modal classe. This conflit make dialog height too large
